### PR TITLE
ci: fix scorecard SARIF upload

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,4 +28,9 @@ jobs:
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
+
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17
+        with:
+          sarif_file: scorecard-results.sarif


### PR DESCRIPTION
Fixes the OSSF Scorecard workflow so Scorecard publishing is disabled and SARIF upload is handled by CodeQL upload-sarif.\n\nValidation:\n- repo-trust scan . --format console